### PR TITLE
Ensure single decimal for the sound slider

### DIFF
--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -152,7 +152,7 @@ export const Settings: React.FC = () => {
                                     max={1}
                                     step={0.1}
                                     style={{ width: "100px" }}
-                                    value={playSoundVolume}
+                                    value={playSoundVolume.toFixed(1)}
                                     onChange={setPlaySoundVolume}
                                     onChangeEnd={(value) => {
                                         events.settings_changed(


### PR DESCRIPTION
The Play sound on match found slider tooltip shows for some values a large number of decimals which appears to be a rounding error. This should fix it.