### PR TITLE
perf: optimize parse_log_file_reverse function

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +192,17 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "url",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -343,6 +360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +412,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +494,7 @@ dependencies = [
 name = "coh3-stats-desktop-app"
 version = "1.2.2"
 dependencies = [
+ "criterion",
  "log",
  "machine-uid",
  "nom",
@@ -531,6 +603,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +646,30 @@ checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.8.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -749,6 +881,12 @@ name = "dunce"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "embed_plist"
@@ -1265,6 +1403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1694,6 +1847,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1980,6 +2142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "open"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2232,12 @@ dependencies = [
  "libc",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -2284,6 +2458,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2681,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
 dependencies = [
  "cty",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3364,6 +3588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -705,7 +705,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -725,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -755,7 +755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1455,7 +1455,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2180,7 +2180,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2390,7 +2390,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2404,7 +2404,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2545,7 +2545,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "version_check",
 ]
 
@@ -2568,9 +2568,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -2586,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -2762,9 +2762,12 @@ dependencies = [
 
 [[package]]
 name = "rev_lines"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eb52b6664d331053136fcac7e4883bdc6f5fc04a6aab3b0f75eafb80ab88b3"
+checksum = "ed62916ac7a5ccbf13fa5e1d303029ff015600fee841756dfc134a1ac62bf05f"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "rfd"
@@ -2944,7 +2947,7 @@ checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2966,7 +2969,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3000,7 +3003,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3022,7 +3025,7 @@ checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3206,7 +3209,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3214,6 +3217,17 @@ name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3411,7 +3425,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -3601,22 +3615,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3725,7 +3739,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3954,7 +3968,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -3988,7 +4002,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4076,7 +4090,7 @@ checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -4180,7 +4194,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba01f98f509cb5dc05f4e5fc95e535f78260f15fea8fe1a8abdd08f774f1cee7"
 dependencies = [
- "syn",
+ "syn 1.0.105",
  "windows-tokens",
 ]
 
@@ -4521,7 +4535,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.105",
  "zvariant_utils",
 ]
 
@@ -4570,7 +4584,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "zvariant_utils",
 ]
 
@@ -4582,5 +4596,5 @@ checksum = "53b22993dbc4d128a17a3b6c92f1c63872dd67198537ee728d8b5d7c40640a8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,10 +29,17 @@ log = "^0.4"
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 machine-uid = "0.2.0"
 
+[dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
 default = [ "custom-protocol" ]
-# this feature is used used for production builds where `devPath` points to the filesystem
+# this feature is used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = [ "tauri/custom-protocol" ]
+
+[[bench]]
+name = "parse_log_file_reverse"
+harness = false

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,15 +11,15 @@ rust-version = "1.57"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.2", features = [] }
+tauri-build = { version = "1.2", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = {version = "1.2", features = ["api-all", "updater"] }
+tauri = { version = "1.2", features = ["api-all", "updater"] }
 notify = "5.0.0"
 nom = "7.1.1"
-rev_lines = "0.2.1"
+rev_lines = "0.3.0"
 window-shadows = "0.2.0"
 tauri-plugin-window-state = "0.1"
 tauri-plugin-fs-watch = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
@@ -35,10 +35,10 @@ criterion = { version = "0.4", features = ["html_reports"] }
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = [ "custom-protocol" ]
+default = ["custom-protocol"]
 # this feature is used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
-custom-protocol = [ "tauri/custom-protocol" ]
+custom-protocol = ["tauri/custom-protocol"]
 
 [[bench]]
 name = "parse_log_file_reverse"

--- a/src-tauri/benches/parse_log_file_reverse.rs
+++ b/src-tauri/benches/parse_log_file_reverse.rs
@@ -1,0 +1,10 @@
+use coh3_stats_desktop_app::parse_log_file::parse_log_file_reverse;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("parse_log_file_reverse 2mb", |b| b.iter(|| parse_log_file_reverse("tests/warnings-2mb.log".to_string())));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src-tauri/benches/parse_log_file_reverse.rs
+++ b/src-tauri/benches/parse_log_file_reverse.rs
@@ -1,9 +1,10 @@
 use coh3_stats_desktop_app::parse_log_file::parse_log_file_reverse;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("parse_log_file_reverse 2mb", |b| b.iter(|| parse_log_file_reverse("tests/warnings-2mb.log".to_string())));
+    c.bench_function("parse_log_file_reverse 2mb", |b| {
+        b.iter(|| parse_log_file_reverse("tests/warnings-2mb.log".to_string()))
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,2 +1,1 @@
-
 pub mod parse_log_file;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,2 @@
+
+pub mod parse_log_file;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,38 +4,48 @@
 )]
 
 extern crate machine_uid;
+use coh3_stats_desktop_app::parse_log_file;
 use std::path::Path;
 use tauri::Manager;
+use tauri_plugin_log::LogTarget;
 use window_shadows::set_shadow;
-use tauri_plugin_log::{LogTarget};
-mod parse_log_file;
 
 #[derive(Clone, serde::Serialize)]
 struct Payload {
-  args: Vec<String>,
-  cwd: String,
+    args: Vec<String>,
+    cwd: String,
 }
 
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![get_default_log_file_path, check_log_file_exists, get_machine_id, parse_log_file::parse_log_file_reverse])
+        .invoke_handler(tauri::generate_handler![
+            get_default_log_file_path,
+            check_log_file_exists,
+            get_machine_id,
+            parse_log_file::parse_log_file_reverse
+        ])
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             let window = app.get_window("main").unwrap();
             window.set_focus().ok();
-            window.request_user_attention(Some(tauri::UserAttentionType::Informational)).ok();
-            
+            window
+                .request_user_attention(Some(tauri::UserAttentionType::Informational))
+                .ok();
+
             //println!("{}, {argv:?}, {cwd}", app.package_info().name);
 
-            app.emit_all("single-instance", Payload { args: argv, cwd }).unwrap();
+            app.emit_all("single-instance", Payload { args: argv, cwd })
+                .unwrap();
         }))
-        .plugin(tauri_plugin_log::Builder::default().targets([
-            LogTarget::LogDir,
-            LogTarget::Stdout,
-        ]).build())
+        .plugin(
+            tauri_plugin_log::Builder::default()
+                .targets([LogTarget::LogDir, LogTarget::Stdout])
+                .build(),
+        )
         .plugin(tauri_plugin_fs_watch::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_store::Builder::default().build())
-        .setup(|app| { // Add window shadows
+        .setup(|app| {
+            // Add window shadows
             let window = app.get_window("main").unwrap();
             set_shadow(&window, true).expect("Unsupported platform!");
             Ok(())

--- a/src-tauri/src/parse_log_file.rs
+++ b/src-tauri/src/parse_log_file.rs
@@ -60,44 +60,31 @@ pub struct LogFileData {
 
 #[tauri::command]
 pub fn parse_log_file_reverse(path: String) -> LogFileData {
-  let file = File::open(path).unwrap();
-  let reader = BufReader::new(file);
+    let mut full_game = false;
+    let mut game_running = true;
+    let mut game_loading = false;
+    let mut game_started = false;
+    let mut game_ended = false;
+    let mut map = "".to_string();
+    let mut win_condition = "".to_string();
+    let mut timestamp = "".to_string();
+    let mut game_duration: u64 = 0;
+    let mut left: Vec<PlayerData> = Vec::new();
+    let mut right: Vec<PlayerData> = Vec::new();
+    let mut player_name = "".to_string();
+    let mut player_steam_id = "".to_string();
+    let mut language_code = "".to_string();
 
-  let mut string_array: Vec<String> = Vec::new();
+    // Read log file in reverse order line by line
+    let log_file = BufReader::new(File::open(path).unwrap());
 
-  // Because some of the lines are not UTF-8, I needed to skip them while parsing
-  // this is less effective than using RevLines because we first load the whole log
-  // and than read it backwards. But I couldn't figure out how to fix it with revlines.
-  for result in reader.lines() {
-    match result {
-      Ok(line) => {
-        // If the conversion is successful, process the line
-        string_array.push(line);
-      }
-      Err(_) => {
-        // If the conversion fails, skip the line
-        // println!("Skipped non-UTF-8 line");
-      }
-    }
-  }
-
-  let mut full_game = false;
-  let mut game_running = true;
-  let mut game_loading = false;
-  let mut game_started = false;
-  let mut game_ended = false;
-  let mut map = "".to_string();
-  let mut win_condition = "".to_string();
-  let mut timestamp = "".to_string();
-  let mut game_duration: u64 = 0;
-  let mut left: Vec<PlayerData> = Vec::new();
-  let mut right: Vec<PlayerData> = Vec::new();
-  let mut player_name = "".to_string();
-  let mut player_steam_id = "".to_string();
-  let mut language_code = "".to_string();
-
-  // Read log file in reverse order line by line
-  for line in string_array.iter().rev() {
+    for line in log_file
+        .lines()
+        .filter_map(|x| x.ok())
+        .collect::<Vec<_>>()
+        .iter()
+        .rev()
+    {
 
     // Is the line when the game is being closed correctly
     if nom::bytes::complete::tag::<&str, &str, ()>("Application closed")(line.as_str()).is_ok() {

--- a/src-tauri/src/parse_log_file.rs
+++ b/src-tauri/src/parse_log_file.rs
@@ -1,61 +1,60 @@
-use serde::{Deserialize, Serialize};
-use std::io::BufReader;
-use std::io::BufRead;
-use std::fs::File;
 use log::info;
+use rev_lines::RawRevLines;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum GameState {
-  Closed,
-  Menu,
-  Loading,
-  InGame
+    Closed,
+    Menu,
+    Loading,
+    InGame,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum GameType {
-  Classic,
-  AI,
-  Custom
+    Classic,
+    AI,
+    Custom,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum TeamSide {
-  Axis,
-  Allies,
-  Mixed
+    Axis,
+    Allies,
+    Mixed,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PlayerData {
-  pub ai: bool,
-  pub faction: String,
-  pub relic_id: String,
-  pub name: String,
-  pub position: u8,
-  pub steam_id: String,
-  pub rank: i64,
+    pub ai: bool,
+    pub faction: String,
+    pub relic_id: String,
+    pub name: String,
+    pub position: u8,
+    pub steam_id: String,
+    pub rank: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TeamData {
-  pub players: Vec<PlayerData>,
-  pub side: TeamSide,
+    pub players: Vec<PlayerData>,
+    pub side: TeamSide,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct LogFileData {
-  pub game_state: GameState,
-  pub game_type: GameType,
-  pub timestamp: String,
-  pub duration: u64,
-  pub map: String,
-  pub win_condition: String,
-  pub left: TeamData,
-  pub right: TeamData,
-  pub player_name: String,
-  pub player_steam_id: String,
-  pub language_code: String
+    pub game_state: GameState,
+    pub game_type: GameType,
+    pub timestamp: String,
+    pub duration: u64,
+    pub map: String,
+    pub win_condition: String,
+    pub left: TeamData,
+    pub right: TeamData,
+    pub player_name: String,
+    pub player_steam_id: String,
+    pub language_code: String,
 }
 
 #[tauri::command]
@@ -76,253 +75,290 @@ pub fn parse_log_file_reverse(path: String) -> LogFileData {
     let mut language_code = "".to_string();
 
     // Read log file in reverse order line by line
-    let log_file = BufReader::new(File::open(path).unwrap());
+    let log_file = File::open(path).unwrap();
+    let rev_lines = RawRevLines::new(log_file);
 
-    for line in log_file
-        .lines()
-        .filter_map(|x| x.ok())
-        .collect::<Vec<_>>()
-        .iter()
-        .rev()
-    {
+    for line in rev_lines {
+        let line = line.unwrap();
+        let line = String::from_utf8_lossy(&line);
 
-    // Is the line when the game is being closed correctly
-    if nom::bytes::complete::tag::<&str, &str, ()>("Application closed")(line.as_str()).is_ok() {
-      game_running = false;
-      continue;
-    }
-    
-    if let Ok((tail, parsed_timestamp)) = get_timestamped_line(line.as_str()) {
-
-      // Is the line where a game starts
-      if is_game_start_line(tail) {
-        timestamp = parsed_timestamp.to_string();
-        continue;
-      }
-
-      // Is the line that logs the player steam id
-      if let Ok((steam_id, _)) = get_game_player_steam_id(tail) {
-        player_steam_id = steam_id.to_string();
-        continue;
-      }
-
-      if let Ok((tail, param)) = get_param_line(tail) {
-        if param == "GAME" {
-
-          if let Ok((tail, sub_param)) = get_game_sub_param(tail) {
-            if sub_param == "Scenario" {
-              if let Ok((parsed_map, _)) = get_map_name(tail) {
-                if !full_game {
-                  map = parsed_map.to_string();
-                  //println!("Map {}", map);
-                  full_game = true;
-                }
-              }
-            } else if sub_param == "Win Condition Name" && !full_game {
-              win_condition = tail.trim().to_string();
-              game_loading = true;
-              //println!("Win Condition {}", win_condition);
-            } else if sub_param == "Starting mission" && !full_game {
-              game_started = true;
-            } else if sub_param == "Human Player" && !full_game {
-              if let Ok((without_space, _)) = get_without_leading_space(tail) {
-                if let Ok((tail, position_str)) = nom::bytes::complete::take_until1::<&str, &str, ()>(" ")(without_space) {
-                  if let Ok((tail, _)) = nom::bytes::complete::tag::<&str, &str, ()>(" ")(tail) {
-                    if let Ok((faction, front)) = get_last_separated_by_space(tail) {
-                      if let Ok((side_str, front)) = get_last_separated_by_space(front) {
-                        if let Ok((relic_id, user_name)) = get_last_separated_by_space(front) {
-                          if let Ok(position) = position_str.parse::<u8>() {
-                            if let Ok(side) = side_str.parse::<u8>() {
-                              let player_data = PlayerData {
-                                ai: false,
-                                position,
-                                faction: faction.to_string(),
-                                relic_id: relic_id.to_string(),
-                                name: user_name.to_string(),
-                                steam_id: "".to_string(),
-                                rank: -1,
-                              };
-                              if side == 0 {
-                                left.push(player_data);
-                              } else {
-                                right.push(player_data);
-                              }
-                              //println!("{}", position);
-                              //println!("{}", faction);
-                              //println!("{}", side);
-                              //println!("{}", relic_id);
-                              //println!("{}", user_name);
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            } else if sub_param == "AI Player" && !full_game {
-              if let Ok((without_space, _)) = get_without_leading_space(tail) {
-                if let Ok((tail, position_str)) = nom::bytes::complete::take_until1::<&str, &str, ()>(" ")(without_space) {
-                  if let Ok((tail, _)) = nom::bytes::complete::tag::<&str, &str, ()>(" ")(tail) {
-                    if let Ok((faction, front)) = get_last_separated_by_space(tail) {
-                      if let Ok((side_str, front)) = get_last_separated_by_space(front) {
-                        if let Ok((_, user_name)) = get_last_separated_by_space(front) {
-                          if let Ok(position) = position_str.parse::<u8>() {
-                            if let Ok(side) = side_str.parse::<u8>() {
-                              let player_data = PlayerData {
-                                ai: true,
-                                position,
-                                faction: faction.to_string(),
-                                relic_id: "-1".to_string(),
-                                name: user_name.to_string(),
-                                steam_id: "".to_string(),
-                                rank: -1,
-                              };
-                              if side == 0 {
-                                left.push(player_data);
-                              } else {
-                                right.push(player_data);
-                              }
-                              //println!("{}", position);
-                              //println!("{}", faction);
-                              //println!("{}", side);
-                              //println!("{}", user_name);
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-
-            // Is the line that logs the playing players name
-          } else if let Ok((steam_name, _)) = get_game_player_name(tail) {
-            player_name = steam_name.to_string();
-            break;
-
-            // Is the line that logs the games language
-          } else if let Ok((game_language, _)) = get_game_language(tail) {
-            language_code = game_language.to_string();
-          }
-        } else if param == "MOD" {
-          if let Ok((duration_str, _)) = get_game_over(tail) {
-            if !full_game {
-              if let Ok(duration) = duration_str.parse::<u64>() {
-                game_duration = duration / 8;
-                //println!("Game Duration {}s", duration/8);
-              }
-              game_ended = true;
-            }
-          }
+        // Is the line when the game is being closed correctly
+        if nom::bytes::complete::tag::<&str, &str, ()>("Application closed")(line.as_ref()).is_ok()
+        {
+            game_running = false;
+            continue;
         }
-      }
+
+        if let Ok((tail, parsed_timestamp)) = get_timestamped_line(line.as_ref()) {
+            // Is the line where a game starts
+            if is_game_start_line(tail) {
+                timestamp = parsed_timestamp.to_string();
+                continue;
+            }
+
+            // Is the line that logs the player steam id
+            if let Ok((steam_id, _)) = get_game_player_steam_id(tail) {
+                player_steam_id = steam_id.to_string();
+                continue;
+            }
+
+            if let Ok((tail, param)) = get_param_line(tail) {
+                if param == "GAME" {
+                    if let Ok((tail, sub_param)) = get_game_sub_param(tail) {
+                        if sub_param == "Scenario" {
+                            if let Ok((parsed_map, _)) = get_map_name(tail) {
+                                if !full_game {
+                                    map = parsed_map.to_string();
+                                    //println!("Map {}", map);
+                                    full_game = true;
+                                }
+                            }
+                        } else if sub_param == "Win Condition Name" && !full_game {
+                            win_condition = tail.trim().to_string();
+                            game_loading = true;
+                            //println!("Win Condition {}", win_condition);
+                        } else if sub_param == "Starting mission" && !full_game {
+                            game_started = true;
+                        } else if sub_param == "Human Player" && !full_game {
+                            if let Ok((without_space, _)) = get_without_leading_space(tail) {
+                                if let Ok((tail, position_str)) =
+                                    nom::bytes::complete::take_until1::<&str, &str, ()>(" ")(
+                                        without_space,
+                                    )
+                                {
+                                    if let Ok((tail, _)) =
+                                        nom::bytes::complete::tag::<&str, &str, ()>(" ")(tail)
+                                    {
+                                        if let Ok((faction, front)) =
+                                            get_last_separated_by_space(tail)
+                                        {
+                                            if let Ok((side_str, front)) =
+                                                get_last_separated_by_space(front)
+                                            {
+                                                if let Ok((relic_id, user_name)) =
+                                                    get_last_separated_by_space(front)
+                                                {
+                                                    if let Ok(position) = position_str.parse::<u8>()
+                                                    {
+                                                        if let Ok(side) = side_str.parse::<u8>() {
+                                                            let player_data = PlayerData {
+                                                                ai: false,
+                                                                position,
+                                                                faction: faction.to_string(),
+                                                                relic_id: relic_id.to_string(),
+                                                                name: user_name.to_string(),
+                                                                steam_id: "".to_string(),
+                                                                rank: -1,
+                                                            };
+                                                            if side == 0 {
+                                                                left.push(player_data);
+                                                            } else {
+                                                                right.push(player_data);
+                                                            }
+                                                            //println!("{}", position);
+                                                            //println!("{}", faction);
+                                                            //println!("{}", side);
+                                                            //println!("{}", relic_id);
+                                                            //println!("{}", user_name);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else if sub_param == "AI Player" && !full_game {
+                            if let Ok((without_space, _)) = get_without_leading_space(tail) {
+                                if let Ok((tail, position_str)) =
+                                    nom::bytes::complete::take_until1::<&str, &str, ()>(" ")(
+                                        without_space,
+                                    )
+                                {
+                                    if let Ok((tail, _)) =
+                                        nom::bytes::complete::tag::<&str, &str, ()>(" ")(tail)
+                                    {
+                                        if let Ok((faction, front)) =
+                                            get_last_separated_by_space(tail)
+                                        {
+                                            if let Ok((side_str, front)) =
+                                                get_last_separated_by_space(front)
+                                            {
+                                                if let Ok((_, user_name)) =
+                                                    get_last_separated_by_space(front)
+                                                {
+                                                    if let Ok(position) = position_str.parse::<u8>()
+                                                    {
+                                                        if let Ok(side) = side_str.parse::<u8>() {
+                                                            let player_data = PlayerData {
+                                                                ai: true,
+                                                                position,
+                                                                faction: faction.to_string(),
+                                                                relic_id: "-1".to_string(),
+                                                                name: user_name.to_string(),
+                                                                steam_id: "".to_string(),
+                                                                rank: -1,
+                                                            };
+                                                            if side == 0 {
+                                                                left.push(player_data);
+                                                            } else {
+                                                                right.push(player_data);
+                                                            }
+                                                            //println!("{}", position);
+                                                            //println!("{}", faction);
+                                                            //println!("{}", side);
+                                                            //println!("{}", user_name);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Is the line that logs the playing players name
+                    } else if let Ok((steam_name, _)) = get_game_player_name(tail) {
+                        player_name = steam_name.to_string();
+                        break;
+
+                        // Is the line that logs the games language
+                    } else if let Ok((game_language, _)) = get_game_language(tail) {
+                        language_code = game_language.to_string();
+                    }
+                } else if param == "MOD" {
+                    if let Ok((duration_str, _)) = get_game_over(tail) {
+                        if !full_game {
+                            if let Ok(duration) = duration_str.parse::<u64>() {
+                                game_duration = duration / 8;
+                                //println!("Game Duration {}s", duration/8);
+                            }
+                            game_ended = true;
+                        }
+                    }
+                }
+            }
+        }
     }
 
+    let game_state = determine_game_state(game_running, game_ended, game_loading, game_started);
+    let left_team = get_team_data(left);
+    let right_team = get_team_data(right);
 
-  }
+    info!(
+        "Log file parsed: Found {} players",
+        left_team.players.len() + right_team.players.len()
+    );
 
-  let game_state = determine_game_state(game_running, game_ended, game_loading, game_started);
-  let left_team = get_team_data(left);
-  let right_team = get_team_data(right);
-
-  info!("Log file parsed: Found {} players", left_team.players.len() + right_team.players.len());
-
-  LogFileData {
-    game_state,
-    game_type: determine_game_type(&left_team, &right_team),
-    timestamp,
-    duration: game_duration,
-    map,
-    win_condition,
-    left: left_team,
-    right: right_team,
-    player_name,
-    player_steam_id,
-    language_code
-  }
+    LogFileData {
+        game_state,
+        game_type: determine_game_type(&left_team, &right_team),
+        timestamp,
+        duration: game_duration,
+        map,
+        win_condition,
+        left: left_team,
+        right: right_team,
+        player_name: player_name,
+        player_steam_id: player_steam_id,
+        language_code: language_code,
+    }
 }
 
 fn determine_game_state(running: bool, ended: bool, loading: bool, started: bool) -> GameState {
-  if !running {
-    return GameState::Closed;
-  } else if ended || !loading {
-    return GameState::Menu;
-  } else if started {
-    return GameState::InGame;
-  } else if loading {
-    return GameState::Loading;
-  }
-  GameState::Menu
+    if !running {
+        return GameState::Closed;
+    } else if ended || !loading {
+        return GameState::Menu;
+    } else if started {
+        return GameState::InGame;
+    } else if loading {
+        return GameState::Loading;
+    }
+    GameState::Menu
 }
 
 fn determine_game_type(left_team: &TeamData, right_team: &TeamData) -> GameType {
-  let left_ai_count = get_ai_count(&left_team);
-  let right_ai_count = get_ai_count(&right_team);
-  if left_team.side != TeamSide::Mixed && right_team.side != TeamSide::Mixed && left_team.side != right_team.side {
-    if (left_ai_count + right_ai_count) == 0 {
-      return GameType::Classic
-    } else if (left_ai_count == 0 && right_ai_count == right_team.players.len()) || (right_ai_count == 0 && left_ai_count == left_team.players.len()) {
-      return GameType::AI
+    let left_ai_count = get_ai_count(&left_team);
+    let right_ai_count = get_ai_count(&right_team);
+    if left_team.side != TeamSide::Mixed
+        && right_team.side != TeamSide::Mixed
+        && left_team.side != right_team.side
+    {
+        if (left_ai_count + right_ai_count) == 0 {
+            return GameType::Classic;
+        } else if (left_ai_count == 0 && right_ai_count == right_team.players.len())
+            || (right_ai_count == 0 && left_ai_count == left_team.players.len())
+        {
+            return GameType::AI;
+        }
     }
-  }
-  GameType::Custom
+    GameType::Custom
 }
 
 fn get_ai_count(team: &TeamData) -> usize {
-  let mut count: usize = 0;
-  for player in &team.players {
-    if player.ai {
-      count += 1;
+    let mut count: usize = 0;
+    for player in &team.players {
+        if player.ai {
+            count += 1;
+        }
     }
-  }
-  count
+    count
 }
 
 fn get_team_data(players: Vec<PlayerData>) -> TeamData {
-  let mut mixed = false;
-  let mut last = TeamSide::Mixed;
-  for player in &players {
-    if player.faction == "german" || player.faction == "west_german" {
-      if last == TeamSide::Allies {
-        mixed = true;
-        break;
-      }
-      last = TeamSide::Axis;
-    } else {
-      if last == TeamSide::Axis {
-        mixed = true;
-        break;
-      }
-      last = TeamSide::Allies;
+    let mut mixed = false;
+    let mut last = TeamSide::Mixed;
+    for player in &players {
+        if player.faction == "german" || player.faction == "west_german" {
+            if last == TeamSide::Allies {
+                mixed = true;
+                break;
+            }
+            last = TeamSide::Axis;
+        } else {
+            if last == TeamSide::Axis {
+                mixed = true;
+                break;
+            }
+            last = TeamSide::Allies;
+        }
     }
-  }
-  if mixed {
-    return TeamData { players, side: TeamSide::Mixed }
-  }
-  TeamData { players, side: last }
+    if mixed {
+        return TeamData {
+            players: players,
+            side: TeamSide::Mixed,
+        };
+    }
+    TeamData {
+        players: players,
+        side: last,
+    }
 }
 
 // look for blocks like this:
-// (I) [11:43:31.404] [000007332]: 
-// (E) [11:44:07.831] [000007332]: 
+// (I) [11:43:31.404] [000007332]:
+// (E) [11:44:07.831] [000007332]:
 // if searched tags are found
 // take time code -> eg: 11:44:07.831
 // and return remaining line
 // if not stop with error as soon as tag cannot be found
 fn get_timestamped_line(line: &str) -> nom::IResult<&str, &str> {
-  let (tail, _) = nom::bytes::complete::take_until1("[")(line)?;
-  let (tail, _) = nom::bytes::complete::tag("[")(tail)?;
-  let (tail, time_code) = nom::bytes::complete::take_until1("]")(tail)?;
-  let (tail, _) = nom::bytes::complete::tag("]")(tail)?;
-  let (tail, _) = nom::bytes::complete::take_until1("]: ")(tail)?;
-  let (tail, _) = nom::bytes::complete::tag("]: ")(tail)?;
-  Ok((tail,time_code))
+    let (tail, _) = nom::bytes::complete::take_until1("[")(line)?;
+    let (tail, _) = nom::bytes::complete::tag("[")(tail)?;
+    let (tail, time_code) = nom::bytes::complete::take_until1("]")(tail)?;
+    let (tail, _) = nom::bytes::complete::tag("]")(tail)?;
+    let (tail, _) = nom::bytes::complete::take_until1("]: ")(tail)?;
+    let (tail, _) = nom::bytes::complete::tag("]: ")(tail)?;
+    Ok((tail, time_code))
 }
 
 fn is_game_start_line(timestamped_tail: &str) -> bool {
-  nom::bytes::complete::tag::<_, _, nom::error::Error<_>>("GameApp::SetState : new (Game)")(timestamped_tail).is_ok()
+    nom::bytes::complete::tag::<_, _, nom::error::Error<_>>("GameApp::SetState : new (Game)")(
+        timestamped_tail,
+    )
+    .is_ok()
 }
 
 /*fn get_match_started_line(timestamped_tail: &str) -> nom::IResult<&str, ()> {
@@ -331,70 +367,72 @@ fn is_game_start_line(timestamped_tail: &str) -> bool {
 }*/
 
 fn get_param_line(timestamped_tail: &str) -> nom::IResult<&str, &str> {
-  let (tail, param) = nom::bytes::complete::take_until1(" -- ")(timestamped_tail)?;
-  let (tail, _) = nom::bytes::complete::tag(" -- ")(tail)?;
-  Ok((tail,param))
+    let (tail, param) = nom::bytes::complete::take_until1(" -- ")(timestamped_tail)?;
+    let (tail, _) = nom::bytes::complete::tag(" -- ")(tail)?;
+    Ok((tail, param))
 }
 
 fn get_game_sub_param(game_param_tail: &str) -> nom::IResult<&str, &str> {
-  let (tail, sub_param) = nom::bytes::complete::take_until1(":")(game_param_tail)?;
-  let (tail, _) = nom::bytes::complete::tag(":")(tail)?;
-  Ok((tail,sub_param))
+    let (tail, sub_param) = nom::bytes::complete::take_until1(":")(game_param_tail)?;
+    let (tail, _) = nom::bytes::complete::tag(":")(tail)?;
+    Ok((tail, sub_param))
 }
 
 fn get_game_player_name(game_param_tail: &str) -> nom::IResult<&str, ()> {
-  let (name_tail, _) = nom::bytes::complete::tag("Current Steam name is [")(game_param_tail)?;
-  let (name, _) = get_till_last_tag(name_tail, "]")?;
-  //let (_, name) = nom::bytes::complete::take_until1("]")(name_tail)?;
-  Ok((name,()))
+    let (name_tail, _) = nom::bytes::complete::tag("Current Steam name is [")(game_param_tail)?;
+    let (name, _) = get_till_last_tag(name_tail, "]")?;
+    //let (_, name) = nom::bytes::complete::take_until1("]")(name_tail)?;
+    Ok((name, ()))
 }
 
 fn get_game_language(game_param_tail: &str) -> nom::IResult<&str, ()> {
-  let (language_tail, _) = nom::bytes::complete::tag("[Company of Heroes 3] set to language [")(game_param_tail)?;
-  let (_, language) = nom::bytes::complete::take_until1("]")(language_tail)?;
-  Ok((language,()))
+    let (language_tail, _) =
+        nom::bytes::complete::tag("[Company of Heroes 3] set to language [")(game_param_tail)?;
+    let (_, language) = nom::bytes::complete::take_until1("]")(language_tail)?;
+    Ok((language, ()))
 }
 
 fn get_game_player_steam_id(timestamped_tail: &str) -> nom::IResult<&str, ()> {
-  let (steam_id, _) = nom::bytes::complete::tag("Found profile: /steam/")(timestamped_tail)?;
-  Ok((steam_id,()))
+    let (steam_id, _) = nom::bytes::complete::tag("Found profile: /steam/")(timestamped_tail)?;
+    Ok((steam_id, ()))
 }
 
 fn get_map_name(scenario_tail: &str) -> nom::IResult<&str, &str> {
-  let (tail, front) = nom::bytes::complete::take_until1("\\")(scenario_tail)?;
-  let (tail, _) = nom::bytes::complete::tag("\\")(tail)?;
-  if let Ok((tail, front)) = get_map_name(tail) {
-    return Ok((tail,front))
-  }
-  Ok((tail,front))
+    let (tail, front) = nom::bytes::complete::take_until1("\\")(scenario_tail)?;
+    let (tail, _) = nom::bytes::complete::tag("\\")(tail)?;
+    if let Ok((tail, front)) = get_map_name(tail) {
+        return Ok((tail, front));
+    }
+    Ok((tail, front))
 }
 
 fn get_game_over(mod_param_tail: &str) -> nom::IResult<&str, &str> {
-  let (duration, game_over_message) = nom::bytes::complete::tag("Game Over at frame ")(mod_param_tail)?;
-  Ok((duration, game_over_message))
+    let (duration, game_over_message) =
+        nom::bytes::complete::tag("Game Over at frame ")(mod_param_tail)?;
+    Ok((duration, game_over_message))
 }
 
 fn get_last_separated_by_space(line: &str) -> nom::IResult<&str, &str> {
-  let (tail, front) = nom::bytes::complete::take_until(" ")(line)?;
-  let (tail, _) = nom::bytes::complete::tag(" ")(tail)?;
-  if let Ok((tail, _)) = get_last_separated_by_space(tail) {
-    return Ok((tail, &line[0..(line.len() - tail.len() - 1)]))
-  }
-  Ok((tail, front))
+    let (tail, front) = nom::bytes::complete::take_until(" ")(line)?;
+    let (tail, _) = nom::bytes::complete::tag(" ")(tail)?;
+    if let Ok((tail, _)) = get_last_separated_by_space(tail) {
+        return Ok((tail, &line[0..(line.len() - tail.len() - 1)]));
+    }
+    Ok((tail, front))
 }
 
 fn get_till_last_tag<'a>(line: &'a str, tag: &'a str) -> nom::IResult<&'a str, &'a str> {
-  let (tail, front) = nom::bytes::complete::take_until(tag)(line)?;
-  let (tail, _) = nom::bytes::complete::tag(tag)(tail)?;
-  if let Ok((front, tail)) = get_till_last_tag(tail, tag) {
-    return Ok((front, tail))
-  }
-  Ok((front, tail))
+    let (tail, front) = nom::bytes::complete::take_until(tag)(line)?;
+    let (tail, _) = nom::bytes::complete::tag(tag)(tail)?;
+    if let Ok((front, tail)) = get_till_last_tag(tail, tag) {
+        return Ok((front, tail));
+    }
+    Ok((front, tail))
 }
 
 fn get_without_leading_space(line: &str) -> nom::IResult<&str, ()> {
-  let (without_space, _) = nom::bytes::complete::tag(" ")(line)?;
-  Ok((without_space, ()))
+    let (without_space, _) = nom::bytes::complete::tag(" ")(line)?;
+    Ok((without_space, ()))
 }
 
 /*fn test_logging_solution(line: &str) -> nom::IResult<&str, ()> {
@@ -413,15 +451,15 @@ fn get_without_leading_space(line: &str) -> nom::IResult<&str, ()> {
 mod tests {
     use super::parse_log_file_reverse;
 
-  #[test]
-  fn test_parse_log_file_reverse() {
-    println!("{}", file!());
-    parse_log_file_reverse("tests/warnings.log".to_string());
-  }
+    #[test]
+    fn test_parse_log_file_reverse() {
+        println!("{}", file!());
+        parse_log_file_reverse("tests/warnings.log".to_string());
+    }
 
-  #[test]
-  fn test_parse_log_file_reverse_big_file() {
-    println!("{}", file!());
-    parse_log_file_reverse("tests/warnings-2mb.log".to_string());
-  }
+    #[test]
+    fn test_parse_log_file_reverse_big_file() {
+        println!("{}", file!());
+        parse_log_file_reverse("tests/warnings-2mb.log".to_string());
+    }
 }

--- a/src-tauri/src/parse_log_file.rs
+++ b/src-tauri/src/parse_log_file.rs
@@ -260,9 +260,9 @@ pub fn parse_log_file_reverse(path: String) -> LogFileData {
         win_condition,
         left: left_team,
         right: right_team,
-        player_name: player_name,
-        player_steam_id: player_steam_id,
-        language_code: language_code,
+        player_name,
+        player_steam_id,
+        language_code,
     }
 }
 
@@ -280,8 +280,8 @@ fn determine_game_state(running: bool, ended: bool, loading: bool, started: bool
 }
 
 fn determine_game_type(left_team: &TeamData, right_team: &TeamData) -> GameType {
-    let left_ai_count = get_ai_count(&left_team);
-    let right_ai_count = get_ai_count(&right_team);
+    let left_ai_count = get_ai_count(left_team);
+    let right_ai_count = get_ai_count(right_team);
     if left_team.side != TeamSide::Mixed
         && right_team.side != TeamSide::Mixed
         && left_team.side != right_team.side
@@ -327,12 +327,12 @@ fn get_team_data(players: Vec<PlayerData>) -> TeamData {
     }
     if mixed {
         return TeamData {
-            players: players,
+            players,
             side: TeamSide::Mixed,
         };
     }
     TeamData {
-        players: players,
+        players,
         side: last,
     }
 }

--- a/src-tauri/src/parse_log_file.rs
+++ b/src-tauri/src/parse_log_file.rs
@@ -421,3 +421,20 @@ fn get_without_leading_space(line: &str) -> nom::IResult<&str, ()> {
   };
   Ok(("without_space", ()))
 }*/
+
+#[cfg(test)]
+mod tests {
+    use super::parse_log_file_reverse;
+
+  #[test]
+  fn test_parse_log_file_reverse() {
+    println!("{}", file!());
+    parse_log_file_reverse("tests/warnings.log".to_string());
+  }
+
+  #[test]
+  fn test_parse_log_file_reverse_big_file() {
+    println!("{}", file!());
+    parse_log_file_reverse("tests/warnings-2mb.log".to_string());
+  }
+}


### PR DESCRIPTION
Work on getting the performance back in `parse_log_file_reverse` after `rev_lines::RevLines` had to be abandoned.