### PR TITLE
fix: explicitly save window state on click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coh3-stats-desktop-app",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "repository": {
     "url": "https://github.com/cohstats/coh3-stats-desktop-app"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "react-router-dom": "6.26.0",
     "tauri-plugin-fs-watch-api": "https://github.com/tauri-apps/tauri-plugin-fs-watch",
     "tauri-plugin-log-api": "https://github.com/tauri-apps/tauri-plugin-log",
-    "tauri-plugin-store-api": "https://github.com/tauri-apps/tauri-plugin-store"
+    "tauri-plugin-store-api": "https://github.com/tauri-apps/tauri-plugin-store",
+    "tauri-plugin-window-state-api": "https://github.com/tauri-apps/tauri-plugin-window-state#v1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "1.6.1",

--- a/src/WindowTitleBar.tsx
+++ b/src/WindowTitleBar.tsx
@@ -5,6 +5,7 @@ import logo from "./assets/logo/32x32.png"
 import { Routes } from "./Router"
 import classes from "./WindowTitleBar.module.css"
 import React from "react"
+import { saveWindowState, StateFlags } from "tauri-plugin-window-state-api"
 
 export interface WindowTitleBarProps {
   children?: React.ReactNode
@@ -77,7 +78,10 @@ export const WindowTitleBar: React.FC<WindowTitleBarProps> = ({ children }) => {
               ☐
             </a>
             <a
-              onClick={() => appWindow.close()}
+              onClick={async () => {
+                await saveWindowState(StateFlags.ALL)
+                await appWindow.close()
+              }}
               className={`${classes.link} ${classes.closeButton} ${classes.windowButton}`}
             >
               X

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,6 +4316,12 @@ tar-stream@^2.1.4, tar-stream@^2.2.0:
   dependencies:
     "@tauri-apps/api" "1.5.3"
 
+"tauri-plugin-window-state-api@https://github.com/tauri-apps/tauri-plugin-window-state#v1":
+  version "0.0.0"
+  resolved "https://github.com/tauri-apps/tauri-plugin-window-state#aa0b2a9cbf96f87a172e999670be79c4bb5d67dd"
+  dependencies:
+    "@tauri-apps/api" "1.6.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
This PR updates the `WindowTitleBar.tsx` component to explicitly save window state on click. This is to address a discrepancy where closing the window using the custom titlebar would not save the state.

Fixes #139 